### PR TITLE
disable keep-alive

### DIFF
--- a/lib/wpt-runner.js
+++ b/lib/wpt-runner.js
@@ -95,6 +95,9 @@ function runTest(url, setup, reporter) {
 
     jsdom.env({
       url,
+      agentOptions: {
+        keepAlive: false
+      },
       features: {
         FetchExternalResources: ["script", "frame", "iframe", "link"],
         ProcessExternalResources: ["script"]


### PR DESCRIPTION
This was causing the server to stay running way longer
than necessary. The default timeout is 2 minutes.

Closes #2.