### PR TITLE
Upgrade to jsdom 11

### DIFF
--- a/lib/wpt-runner.js
+++ b/lib/wpt-runner.js
@@ -107,55 +107,55 @@ function runTest(url, setup, reporter) {
       runScripts: "dangerously",
       virtualConsole: new VirtualConsole().sendTo(console)
     }).then(dom => {
-        let hasFailed = false;
-        const { window } = dom;
+      let hasFailed = false;
+      const { window } = dom;
 
+      // jsdom does not have worker support; make the tests silently skip that
+      window.Worker = class {};
+      window.SharedWorker = class {};
+
+      setup(window);
+
+      /* eslint-disable no-underscore-dangle */
+      window.__setupJSDOMReporter = () => {
+        /* eslint-enable no-underscore-dangle */
         // jsdom does not have worker support; make the tests silently skip that
-        window.Worker = class {};
-        window.SharedWorker = class {};
 
-        setup(window);
+        /* eslint-disable camelcase */
+        window.fetch_tests_from_worker = () => {};
+        /* eslint-enable camelcase */
 
-        /* eslint-disable no-underscore-dangle */
-        window.__setupJSDOMReporter = () => {
-          /* eslint-enable no-underscore-dangle */
-          // jsdom does not have worker support; make the tests silently skip that
+        window.add_result_callback(test => {
+          if (test.status === 1) {
+            reporter.fail(`${test.name}\n`);
+            reporter.reportStack(`${test.message}\n${test.stack}`);
+            hasFailed = true;
+          } else if (test.status === 2) {
+            reporter.fail(`${test.name} (timeout)\n`);
+            reporter.reportStack(`${test.message}\n${test.stack}`);
+            hasFailed = true;
+          } else if (test.status === 3) {
+            reporter.fail(`${test.name} (incomplete)\n`);
+            reporter.reportStack(`${test.message}\n${test.stack}`);
+            hasFailed = true;
+          } else {
+            reporter.pass(test.name);
+          }
+        });
 
-          /* eslint-disable camelcase */
-          window.fetch_tests_from_worker = () => {};
-          /* eslint-enable camelcase */
+        window.add_completion_callback((tests, harnessStatus) => {
+          if (harnessStatus.status === 2) {
+            reporter.fail("test harness should not timeout");
+            resolve(false);
+          }
 
-          window.add_result_callback(test => {
-            if (test.status === 1) {
-              reporter.fail(`${test.name}\n`);
-              reporter.reportStack(`${test.message}\n${test.stack}`);
-              hasFailed = true;
-            } else if (test.status === 2) {
-              reporter.fail(`${test.name} (timeout)\n`);
-              reporter.reportStack(`${test.message}\n${test.stack}`);
-              hasFailed = true;
-            } else if (test.status === 3) {
-              reporter.fail(`${test.name} (incomplete)\n`);
-              reporter.reportStack(`${test.message}\n${test.stack}`);
-              hasFailed = true;
-            } else {
-              reporter.pass(test.name);
-            }
-          });
-
-          window.add_completion_callback((tests, harnessStatus) => {
-            if (harnessStatus.status === 2) {
-              reporter.fail("test harness should not timeout");
-              resolve(false);
-            }
-
-            resolve(!hasFailed);
-            window.close();
-          });
-        };
+          resolve(!hasFailed);
+          window.close();
+        });
+      };
     }).catch(err => {
-        reporter.reportStack(err.stack);
-        resolve(false);
+      reporter.reportStack(err.stack);
+      resolve(false);
     });
   });
 }

--- a/lib/wpt-runner.js
+++ b/lib/wpt-runner.js
@@ -4,7 +4,7 @@ const http = require("http");
 const path = require("path");
 const fs = require("fs");
 const st = require("st");
-const jsdom = require("jsdom");
+const { JSDOM, VirtualConsole } = require("jsdom");
 const recursiveReaddirCb = require("recursive-readdir");
 const consoleReporter = require("./console-reporter.js");
 
@@ -104,22 +104,14 @@ function runTest(url, setup, reporter) {
   return new Promise(resolve => {
     let hasFailed = false;
 
-    jsdom.env({
-      url,
-      agentOptions: {
-        keepAlive: false
-      },
-      features: {
-        FetchExternalResources: ["script", "frame", "iframe", "link"],
-        ProcessExternalResources: ["script"]
-      },
-      virtualConsole: jsdom.createVirtualConsole().sendTo(console),
-      created(err, window) {
-        if (err) {
-          reporter.reportStack(err.stack);
-          resolve(false);
-          return;
-        }
+    JSDOM
+      .fromURL(url, {
+        resources: "usable",
+        runScripts: "dangerously",
+        virtualConsole: new VirtualConsole().sendTo(console)
+      })
+      .then(dom => {
+        const { window } = dom;
 
         // jsdom does not have worker support; make the tests silently skip that
         window.Worker = class {};
@@ -164,13 +156,11 @@ function runTest(url, setup, reporter) {
             window.close();
           });
         };
-      },
-
-      loaded(err) {
+      })
+      .catch(err => {
         reporter.reportStack(err.stack);
         resolve(false);
-      }
-    });
+      });
   });
 }
 

--- a/lib/wpt-runner.js
+++ b/lib/wpt-runner.js
@@ -102,15 +102,12 @@ function setupServer(testsPath, rootURL) {
 
 function runTest(url, setup, reporter) {
   return new Promise(resolve => {
-    let hasFailed = false;
-
-    JSDOM
-      .fromURL(url, {
-        resources: "usable",
-        runScripts: "dangerously",
-        virtualConsole: new VirtualConsole().sendTo(console)
-      })
-      .then(dom => {
+    JSDOM.fromURL(url, {
+      resources: "usable",
+      runScripts: "dangerously",
+      virtualConsole: new VirtualConsole().sendTo(console)
+    }).then(dom => {
+        let hasFailed = false;
         const { window } = dom;
 
         // jsdom does not have worker support; make the tests silently skip that
@@ -156,11 +153,10 @@ function runTest(url, setup, reporter) {
             window.close();
           });
         };
-      })
-      .catch(err => {
+    }).catch(err => {
         reporter.reportStack(err.stack);
         resolve(false);
-      });
+    });
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "colors": "^1.1.2",
-    "jsdom": "^9.8.3",
+    "jsdom": "^11.6.2",
     "recursive-readdir": "^2.1.0",
     "st": "^1.2.0",
     "yargs": "^6.3.0"


### PR DESCRIPTION
This upgrades `jsdom` to version 11.6.2. The code now uses the new API [introduced in version 10](https://github.com/jsdom/jsdom/blob/10.0.0/Changelog.md).

As of version 10, `jsdom` only supports Node 6 and up. I'm not sure what the minimum Node requirements are for `wpt-runner`, so this may or may not be a breaking change.

I've confirmed that this PR works with the current [`whatwg/streams` reference implementation](https://github.com/whatwg/streams/tree/37ace3d5f16cbea7aec4a0c80532c95059994d51/reference-implementation). I am not aware of any other projects using `wpt-runner` though, so this might need some more field testing first.