### PR TITLE
Copy testharness.js before packing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 /npm-debug.log
+/testharness/

--- a/lib/wpt-runner.js
+++ b/lib/wpt-runner.js
@@ -8,7 +8,7 @@ const { JSDOM, VirtualConsole } = require("jsdom");
 const recursiveReaddirCb = require("recursive-readdir");
 const consoleReporter = require("./console-reporter.js");
 
-const testharnessPath = path.resolve(__dirname, "../web-platform-tests/resources/testharness.js");
+const testharnessPath = path.resolve(__dirname, "../testharness/testharness.js");
 
 module.exports = (testsPath, {
       rootURL = "/",

--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
   "files": [
     "lib/",
     "bin/",
-    "web-platform-tests/resources/testharness.js"
+    "testharness/"
   ],
   "scripts": {
     "test": "mocha",
-    "lint": "eslint lib bin"
+    "lint": "eslint lib bin",
+    "prepare": "npm run copy-testharness",
+    "copy-testharness": "copyfiles -u 2 web-platform-tests/resources/testharness.js testharness/"
   },
   "dependencies": {
     "colors": "^1.1.2",
@@ -31,6 +33,7 @@
     "yargs": "^6.3.0"
   },
   "devDependencies": {
+    "copyfiles": "^2.0.0",
     "eslint": "^3.9.1"
   }
 }


### PR DESCRIPTION
Copy `testharness.js` from `web-platform-tests/resources/` to `testharness/` before `npm pack`, and use this copy in the library code.

Fixes #7 (sort of).