### PR TITLE
Log original error stack if available

### DIFF
--- a/lib/wpt-runner.js
+++ b/lib/wpt-runner.js
@@ -116,10 +116,16 @@ function setupServer(testsPath, rootURL) {
 
 function runTest(url, setup, reporter) {
   return new Promise(resolve => {
+    const virtualConsole = new VirtualConsole()
+      .sendTo(console, { omitJSDOMErrors: true })
+      // log original error stack if available
+      // eslint-disable-next-line no-console
+      .on("jsdomError", e => console.error(e.detail.stack || e.detail));
+
     JSDOM.fromURL(url, {
       resources: "usable",
       runScripts: "dangerously",
-      virtualConsole: new VirtualConsole().sendTo(console)
+      virtualConsole
     }).then(dom => {
       let hasFailed = false;
       const { window } = dom;

--- a/lib/wpt-runner.js
+++ b/lib/wpt-runner.js
@@ -118,9 +118,16 @@ function runTest(url, setup, reporter) {
   return new Promise(resolve => {
     const virtualConsole = new VirtualConsole()
       .sendTo(console, { omitJSDOMErrors: true })
-      // log original error stack if available
-      // eslint-disable-next-line no-console
-      .on("jsdomError", e => console.error(e.detail.stack || e.detail));
+      .on("jsdomError", e => {
+        // eslint-disable-function no-console
+
+        // Especially for a test runner, we want to surface unhandled exception stacks very directly.
+        if (e.type === "unhandled exception") {
+          console.error(e.detail.stack || e.detail);
+        } else {
+          console.error(e.stack, e.detail.stack || e.detail);
+        }
+      });
 
     JSDOM.fromURL(url, {
       resources: "usable",


### PR DESCRIPTION
When `jsdom` turns an uncaught error into a `jsdomError` event, it places the original error in `e.detail` ([source](https://github.com/jsdom/jsdom/blob/13.0.0/lib/jsdom/living/helpers/runtime-script-errors.js#L67)). When a `VirtualConsole` receives such event, it calls `console.error(e.stack, e.detail)` ([source](https://github.com/jsdom/jsdom/blob/13.0.0/lib/jsdom/virtual-console.js#L29)). This logs the stack trace of the `jsdomError`, which is not very helpful since it always points to internal code of `jsdom`.

This PR uses a custom `VirtualConsole` that logs `e.detail.stack` if available, which is the stack trace of *the original error*. This provides a more helpful stack trace when debugging test failures. 🙂

_Original from [my comment](https://github.com/whatwg/streams/issues/985#issuecomment-466709728) in whatwg/streams#985_