### PR TITLE
Update minimum Node version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "copy-resources": "copyfiles -u 2 wpt/resources/testharness.js test/tests/resources/"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 10"
   },
   "dependencies": {
     "colors": "^1.4.0",


### PR DESCRIPTION
In #18, the jsdom dependency was updated to version 16, which requires Node 10 or higher. This project should also list this minimum requirement in its `package.json`.