### PR TITLE
Copy and serve idlharness and WebIDLParser from WPT

### DIFF
--- a/lib/wpt-runner.js
+++ b/lib/wpt-runner.js
@@ -14,7 +14,7 @@ const { AnyHtmlHandler, WindowHandler } = require("./internal/serve.js");
 const testharnessPath = path.resolve(__dirname, "../testharness/testharness.js");
 const idlharnessPath = path.resolve(__dirname, "../testharness/idlharness.js");
 const webidl2jsPath = path.resolve(__dirname, "../testharness/webidl2/lib/webidl2.js");
-const testdriverDummy = fs.readFileSync(path.resolve(__dirname, "./testdriver-dummy.js"));
+const testdriverDummyPath = path.resolve(__dirname, "./testdriver-dummy.js");
 
 module.exports = (testsPath, {
   rootURL = "/",
@@ -116,7 +116,7 @@ function setupServer(testsPath, rootURL) {
         }
 
         case "/resources/testdriver.js": {
-          res.end(testdriverDummy);
+          fs.createReadStream(testdriverDummyPath).pipe(res);
           break;
         }
 

--- a/lib/wpt-runner.js
+++ b/lib/wpt-runner.js
@@ -12,6 +12,8 @@ const { SourceFile } = require("./internal/sourcefile.js");
 const { AnyHtmlHandler, WindowHandler } = require("./internal/serve.js");
 
 const testharnessPath = path.resolve(__dirname, "../testharness/testharness.js");
+const idlharnessPath = path.resolve(__dirname, "../testharness/idlharness.js");
+const webidl2jsPath = path.resolve(__dirname, "../testharness/webidl2/lib/webidl2.js");
 const testdriverDummy = fs.readFileSync(path.resolve(__dirname, "./testdriver-dummy.js"));
 
 module.exports = (testsPath, {
@@ -80,6 +82,16 @@ function setupServer(testsPath, rootURL) {
       switch (pathname) {
         case "/resources/testharness.js": {
           fs.createReadStream(testharnessPath).pipe(res);
+          break;
+        }
+
+        case "/resources/idlharness.js": {
+          fs.createReadStream(idlharnessPath).pipe(res);
+          break;
+        }
+
+        case "/resources/WebIDLParser.js": {
+          fs.createReadStream(webidl2jsPath).pipe(res);
           break;
         }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint .",
     "prepare": "npm run copy-testharness",
     "pretest": "npm run copy-resources",
-    "copy-testharness": "copyfiles -u 2 wpt/resources/testharness.js testharness/",
+    "copy-testharness": "copyfiles -u 2 wpt/resources/testharness.js wpt/resources/idlharness.js wpt/resources/webidl2/lib/webidl2.js testharness/",
     "copy-resources": "copyfiles -u 2 wpt/resources/testharness.js test/tests/resources/"
   },
   "engines": {


### PR DESCRIPTION
This copies `idlharness.js` and `webidl2.js` from WPT's [resources](https://github.com/web-platform-tests/wpt/tree/master/resources) directory into the package, so it can be served when running IDL harness tests.

Note that users still need to manually provide a `fetch()` stub, so [the IDL harness can fetch the requested WebIDL interfaces](https://github.com/web-platform-tests/wpt/blob/c5f9e701753a034f99dda16d4716c465bed73e18/resources/idlharness.js#L3533-L3543). For example, they can inject this during the `setup()` hook:
```javascript
const path = require('path');
const fs = require('fs');
const { promisify } = require('util');

const readFileAsync = promisify(fs.readFile);
const wptPath = path.resolve(__dirname, 'web-platform-tests');
const testsPath = path.resolve(wptPath, 'streams');

await wptRunner(testsPath, {
  setup(window) {
    window.fetch = async function (url) {
      const filePath = path.join(wptPath, url);
      if (!filePath.startsWith(wptPath)) {
        throw new TypeError('Invalid URL');
      }
      return {
        ok: true,
        async text() {
          return await readFileAsync(filePath, { encoding: 'utf8' });
        }
      };
    };
  },
}
```

Part of whatwg/streams#1044