### PR TITLE
Handle ERROR and PRECONDITION_FAILED statuses from test harness

### DIFF
--- a/lib/wpt-runner.js
+++ b/lib/wpt-runner.js
@@ -194,7 +194,11 @@ function runTest(url, setup, reporter) {
         });
 
         window.add_completion_callback((tests, harnessStatus) => {
-          if (harnessStatus.status === 2) {
+          if (harnessStatus.status === 1) {
+            reporter.fail("test harness threw unexpected error");
+            reporter.reportStack(`${harnessStatus.message}\n${harnessStatus.stack}`);
+            resolve(false);
+          } else if (harnessStatus.status === 2) {
             reporter.fail("test harness should not timeout");
             resolve(false);
           }

--- a/lib/wpt-runner.js
+++ b/lib/wpt-runner.js
@@ -176,7 +176,9 @@ function runTest(url, setup, reporter) {
         /* eslint-enable camelcase */
 
         window.add_result_callback(test => {
-          if (test.status === 1) {
+          if (test.status === 0) {
+            reporter.pass(test.name);
+          } else if (test.status === 1) {
             reporter.fail(`${test.name}\n`);
             reporter.reportStack(`${test.message}\n${test.stack}`);
             hasFailed = true;
@@ -189,21 +191,26 @@ function runTest(url, setup, reporter) {
             reporter.reportStack(`${test.message}\n${test.stack}`);
             hasFailed = true;
           } else {
-            reporter.pass(test.name);
+            reporter.fail(`unknown test status: ${test.status}`);
+            hasFailed = true;
           }
         });
 
         window.add_completion_callback((tests, harnessStatus) => {
-          if (harnessStatus.status === 1) {
+          if (harnessStatus.status === 0) {
+            resolve(!hasFailed);
+          } else if (harnessStatus.status === 1) {
             reporter.fail("test harness threw unexpected error");
             reporter.reportStack(`${harnessStatus.message}\n${harnessStatus.stack}`);
             resolve(false);
           } else if (harnessStatus.status === 2) {
             reporter.fail("test harness should not timeout");
             resolve(false);
+          } else {
+            reporter.fail(`unknown test harness status: ${harnessStatus.status}`);
+            resolve(false);
           }
 
-          resolve(!hasFailed);
           window.close();
         });
       };

--- a/lib/wpt-runner.js
+++ b/lib/wpt-runner.js
@@ -190,6 +190,10 @@ function runTest(url, setup, reporter) {
             reporter.fail(`${test.name} (incomplete)\n`);
             reporter.reportStack(`${test.message}\n${test.stack}`);
             hasFailed = true;
+          } else if (test.status === 4) {
+            reporter.fail(`${test.name} (precondition failed)\n`);
+            reporter.reportStack(`${test.message}\n${test.stack}`);
+            hasFailed = true;
           } else {
             reporter.fail(`unknown test status: ${test.status}`);
             hasFailed = true;
@@ -205,6 +209,10 @@ function runTest(url, setup, reporter) {
             resolve(false);
           } else if (harnessStatus.status === 2) {
             reporter.fail("test harness should not timeout");
+            resolve(false);
+          } else if (harnessStatus.status === 4) {
+            reporter.fail("test harness precondition failed");
+            reporter.reportStack(`${harnessStatus.message}\n${harnessStatus.stack}`);
             resolve(false);
           } else {
             reporter.fail(`unknown test harness status: ${harnessStatus.status}`);


### PR DESCRIPTION
When an uncaught error happens during an test, the test harness sets the status to `ERROR` (1) or `PRECONDITION_FAILED` (4), [see documentation](https://web-platform-tests.org/writing-tests/testharness-api.html#callback-api). wpt-runner currently ignores these statuses, and incorrectly marks the tests as "passed". This PR fixes that.

See whatwg/streams#1112.