### PR TITLE
Update WPT

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,3 @@
-/test/tests/resources/
+/common/
 /testharness/
 /wpt/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /node_modules/
 /npm-debug.log
 /testharness/
-/test/tests/resources/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /npm-debug.log
+/common/
 /testharness/

--- a/lib/wpt-runner.js
+++ b/lib/wpt-runner.js
@@ -14,6 +14,7 @@ const { AnyHtmlHandler, WindowHandler } = require("./internal/serve.js");
 const testharnessPath = path.resolve(__dirname, "../testharness/testharness.js");
 const idlharnessPath = path.resolve(__dirname, "../testharness/idlharness.js");
 const webidl2jsPath = path.resolve(__dirname, "../testharness/webidl2/lib/webidl2.js");
+const gcPath = path.resolve(__dirname, "../common/gc.js");
 const testdriverDummyPath = path.resolve(__dirname, "./testdriver-dummy.js");
 
 module.exports = (testsPath, {
@@ -92,6 +93,11 @@ function setupServer(testsPath, rootURL) {
 
         case "/resources/WebIDLParser.js": {
           fs.createReadStream(webidl2jsPath).pipe(res);
+          break;
+        }
+
+        case "/common/gc.js": {
+          fs.createReadStream(gcPath).pipe(res);
           break;
         }
 

--- a/package.json
+++ b/package.json
@@ -25,9 +25,7 @@
     "test": "node test/runner.js",
     "lint": "eslint .",
     "prepare": "npm run copy-testharness",
-    "pretest": "npm run copy-resources",
     "copy-testharness": "copyfiles -u 2 wpt/resources/testharness.js wpt/resources/idlharness.js wpt/resources/webidl2/lib/webidl2.js testharness/",
-    "copy-resources": "copyfiles -u 2 wpt/resources/testharness.js test/tests/resources/"
   },
   "engines": {
     "node": ">= 16"

--- a/package.json
+++ b/package.json
@@ -19,13 +19,15 @@
   "files": [
     "lib/",
     "bin/",
+    "common/",
     "testharness/"
   ],
   "scripts": {
     "test": "node test/runner.js",
     "lint": "eslint .",
-    "prepare": "npm run copy-testharness",
+    "prepare": "npm run copy-testharness && npm run copy-common",
     "copy-testharness": "copyfiles -u 2 wpt/resources/testharness.js wpt/resources/idlharness.js wpt/resources/webidl2/lib/webidl2.js testharness/",
+    "copy-common": "copyfiles -u 2 wpt/common/gc.js common/"
   },
   "engines": {
     "node": ">= 16"


### PR DESCRIPTION
[/streams/readable-streams/garbage-collection.any.js](https://github.com/web-platform-tests/wpt/blob/f853785cb85b57e9c8af5dd1ce7c01d1ce9af60b/streams/readable-streams/garbage-collection.any.js#L3) now requires `/common/gc.js`, so wpt-runner needs to include and serve this file.

I also removed `/test/tests/resources/`, since it wasn't actually being used. 🤷